### PR TITLE
Add more RAM dump information

### DIFF
--- a/gdm600/README
+++ b/gdm600/README
@@ -30,13 +30,15 @@ Some stations don't support dumping of firmware through serial port from firmwar
 
 Pencil trick:
 
-During booting rom checks checksum of the firmware in ram, if the check is ok it executes the firmwar. If check is bad, loader code is entered. This code lets you update content of ram.
+During booting rom checks checksum of the firmware in ram, if the check is ok it executes the firmware. If check is bad, loader code is entered. This code lets you update content of ram.
 
-You need to find 74HC573 chip on the board. During boot touch inputs of this chip using very blunt pencil - short data pins. This will cause the checksum to be temporarily corrupt and boot code will enter loader.
+You need to find 74HC573 chip on the board. During boot touch inputs (D0-D7) of this chip using very blunt pencil - short data pins. This will cause the checksum to be temporarily corrupt and boot code will enter loader. Before the first beep but after powerup has started seems to be the right time to short the pins. The control panel may need to be disconnected for this to work.
+
+An alternative may exist on some firmware/boards. Holding TX of the 87C51 low tells the loader to enter console mode. If there is an unpopulated 4 pin header and pin 4 is connected to TX, you can short that pin to any ground while powering up the instrument.
 
 Loader has several commands - few very dangerous at this point. OV* is the most interesting one. Start terminal emulator (realterm, teraterm) enable output capture and execute OV* command.
 
 
-dump2srec.py will help you to convert this dump into file that can be loaded by upload.py
+dump2srec.py will help you to convert this dump into file that can be loaded by upload.py. srec2binarysplit.py can split a dump in to the various banks as files. Be sure to read the code/comments to select the right things for your specific unit.
 
 It has not been tested on this type of stations.

--- a/gdm600/dump2srec.py
+++ b/gdm600/dump2srec.py
@@ -14,9 +14,9 @@ with open(sys.argv[1], "r") as fin:
             break
 
         if "," not in l:
-            continue
-
-        ts, dat = l.split(",")
+            dat = l
+        else:
+            ts, dat = l.split(",")
 
         if "Bank #" in dat:
             bank+=1
@@ -105,7 +105,7 @@ def srec(t, a, d = None):
 #    with open("bank%d.bin" % i, "wb") as fout:
 #        fout.write(banks[i])
 
-with open("fw.s", "wt") as fout:
+with open("fw.s", "wt", newline="\n") as fout:
     for i in range(0x20, 0x8000, 16):
         data = mem_main[i:i+16]
         if sum(data) == 0:
@@ -113,7 +113,7 @@ with open("fw.s", "wt") as fout:
         s = srec(1, i, data)
 #        print("%x" % i, s)
         fout.write(s)
-        fout.write('\r\n')
+        fout.write('\n')
 
     for b in range(1,8):
         for i in range(0, 0x8000, 16):
@@ -124,10 +124,10 @@ with open("fw.s", "wt") as fout:
             s = srec(2, addr, data)
 #            print("%x" % addr, s)
             fout.write(s)
-            fout.write('\r\n')
+            fout.write('\n')
 
     s = srec(9, 0)
     print("%X" % addr, s)
     fout.write(s)
-    fout.write('\r\n')
+    fout.write('\n')
 

--- a/gdm600/srec2binarysplit.py
+++ b/gdm600/srec2binarysplit.py
@@ -53,9 +53,11 @@ with open(sys.argv[1], "rt") as fin:
 
 with open("mainmem.bin", "wb") as fout:
     fout.write(mem_main)
+#    fout.write(mem_main[0x2000:]) # Dump started here for at least one unit
 
 with open("maincode.bin", "wb") as fout:
     fout.write(mem_main[0x2000:])
+#    fout.write(mem_main[0x4000:]) # For 87C51 with 4kB on board ROM
 
 for i in range(1,8):
     with open("bank%d.bin" % i, "wb") as fout:


### PR DESCRIPTION
Added description of how to get in to bootloader mode without the pencil trick for boards that support it. 
I ran in to some line ending weirdness when using the python tools. The modifications are here and I think they should generally work for all platforms? I can remove these changes if you disagree.
Additionally I had to change around some of the dump addresses in the split script, adding those lines as comments in the script for future reference.